### PR TITLE
Update link on cloud.gov site to sandbox account overview.

### DIFF
--- a/templates/notify.tmpl
+++ b/templates/notify.tmpl
@@ -4,7 +4,7 @@
 <p>
   We clear all sandbox content {{.days}} days after the first application or service is created to ensure that sandboxes aren't being used for production applications.
   You may re-deploy your application(s) after your sandbox is cleared and continue to evaluate whether cloud.gov is a good fit for your needs.
-  <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
+  <a href="https://cloud.gov/docs/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
 </p>
 
 

--- a/templates/purge.tmpl
+++ b/templates/purge.tmpl
@@ -4,7 +4,7 @@
 <p>
   We clear all sandbox contents {{.days}} days after the first application or service is created to ensure that sandboxes aren't being used for production applications.
   You may re-deploy your application(s) after your sandbox is cleared and continue to evaluate whether cloud.gov is a good fit for your needs.
-  <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
+  <a href="https://cloud.gov/docs/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
 </p>
 
 <p>We have deleted all applications, service instances, routes, etc., in the {{.org.Name}}/{{.space.Name}} space.

--- a/testdata/notify.html
+++ b/testdata/notify.html
@@ -11,7 +11,7 @@
 <p>
   We clear all sandbox content 90 days after the first application or service is created to ensure that sandboxes aren't being used for production applications.
   You may re-deploy your application(s) after your sandbox is cleared and continue to evaluate whether cloud.gov is a good fit for your needs.
-  <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
+  <a href="https://cloud.gov/docs/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
 </p>
 
 

--- a/testdata/purge.html
+++ b/testdata/purge.html
@@ -11,7 +11,7 @@
 <p>
   We clear all sandbox contents 90 days after the first application or service is created to ensure that sandboxes aren't being used for production applications.
   You may re-deploy your application(s) after your sandbox is cleared and continue to evaluate whether cloud.gov is a good fit for your needs.
-  <a href="https://cloud.gov/overview/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
+  <a href="https://cloud.gov/docs/pricing/free-limited-sandbox/">Learn more about policies for sandbox usage</a>.
 </p>
 
 <p>We have deleted all applications, service instances, routes, etc., in the test-org/test-space space.


### PR DESCRIPTION
## Changes proposed in this pull request:
- This PR updates the link to information on sandbox accounts on the cloud.gov.
- Because of the reorganization of pricing information on the cloud.gov site, the old link no longer works.

## security considerations
None. Content in email templates changed.
