### PR TITLE
Refactor code and add tests

### DIFF
--- a/cmd/purge/cf.go
+++ b/cmd/purge/cf.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/client"
+	"github.com/cloudfoundry-community/go-cfclient/v3/config"
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+)
+
+type ApplicationsClient interface {
+	Delete(ctx context.Context, guid string) (string, error)
+	ListAll(ctx context.Context, opts *client.AppListOptions) ([]*resource.App, error)
+}
+
+type OrganizationsClient interface {
+	ListAll(ctx context.Context, opts *client.OrganizationListOptions) ([]*resource.Organization, error)
+}
+
+type RolesClient interface {
+	CreateSpaceRole(ctx context.Context, spaceGUID, userGUID string, roleType resource.SpaceRoleType) (*resource.Role, error)
+	ListAll(ctx context.Context, opts *client.RoleListOptions) ([]*resource.Role, error)
+}
+
+type ServiceInstancesClient interface {
+	ListAll(ctx context.Context, opts *client.ServiceInstanceListOptions) ([]*resource.ServiceInstance, error)
+}
+
+type SpacesClient interface {
+	ListAll(ctx context.Context, opts *client.SpaceListOptions) ([]*resource.Space, error)
+	ListUsersAll(ctx context.Context, spaceGUID string, opts *client.UserListOptions) ([]*resource.User, error)
+	Create(ctx context.Context, r *resource.SpaceCreate) (*resource.Space, error)
+	Delete(ctx context.Context, guid string) (string, error)
+}
+
+type UsersClient interface {
+	ListAll(ctx context.Context, opts *client.UserListOptions) ([]*resource.User, error)
+}
+
+type cfResourceClient struct {
+	Applications     ApplicationsClient
+	Organizations    OrganizationsClient
+	Roles            RolesClient
+	ServiceInstances ServiceInstancesClient
+	Spaces           SpacesClient
+	Users            UsersClient
+}
+
+func newCFClient(
+	cfApiUrl string,
+	cfApiClientId string,
+	cfApiClientSecret string,
+) (*cfResourceClient, error) {
+	cfg, err := config.NewClientSecret(
+		cfApiUrl,
+		cfApiClientId,
+		cfApiClientSecret,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cf, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &cfResourceClient{
+		Applications:     cf.Applications,
+		Organizations:    cf.Organizations,
+		Roles:            cf.Roles,
+		ServiceInstances: cf.ServiceInstances,
+		Spaces:           cf.Spaces,
+		Users:            cf.Users,
+	}, nil
+}

--- a/cmd/purge/mail.go
+++ b/cmd/purge/mail.go
@@ -28,7 +28,7 @@ type mailer interface {
 	) error
 }
 
-type SMTPMailer struct {
+type smtpMailer struct {
 	options SMTPOptions
 }
 
@@ -42,7 +42,7 @@ func renderTemplate(tmpl *template.Template, data map[string]interface{}) (strin
 }
 
 // sendMail sends email via SMTP
-func (m *SMTPMailer) sendMail(
+func (m *smtpMailer) sendMail(
 	opts SMTPOptions,
 	sender string,
 	subject string,

--- a/cmd/purge/mail.go
+++ b/cmd/purge/mail.go
@@ -18,6 +18,20 @@ type SMTPOptions struct {
 	SMTPCert string `env:"SMTP_CERT"`
 }
 
+type mailer interface {
+	sendMail(
+		opts SMTPOptions,
+		sender string,
+		subject string,
+		body string,
+		recipients []string,
+	) error
+}
+
+type SMTPMailer struct {
+	options SMTPOptions
+}
+
 // renderTemplate renders a template to string
 func renderTemplate(tmpl *template.Template, data map[string]interface{}) (string, error) {
 	buf := bytes.Buffer{}
@@ -28,7 +42,7 @@ func renderTemplate(tmpl *template.Template, data map[string]interface{}) (strin
 }
 
 // sendMail sends email via SMTP
-func sendMail(
+func (m *SMTPMailer) sendMail(
 	opts SMTPOptions,
 	sender string,
 	subject string,
@@ -53,12 +67,12 @@ func sendMail(
 		return err
 	}
 
-	m := gomail.NewMessage()
-	m.SetHeaders(map[string][]string{
+	msg := gomail.NewMessage()
+	msg.SetHeaders(map[string][]string{
 		"From":    {sender},
 		"Subject": {subject},
 		"To":      recipients,
 	})
-	m.SetBody("text/html", body)
-	return gomail.Send(s, m)
+	msg.SetBody("text/html", body)
+	return gomail.Send(s, msg)
 }

--- a/cmd/purge/mail.go
+++ b/cmd/purge/mail.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"html/template"
+
+	"gopkg.in/gomail.v2"
+)
+
+// SMTPOptions describes configation for sending mail via SMTP
+type SMTPOptions struct {
+	SMTPHost string `env:"SMTP_HOST, required"`
+	SMTPPort int    `env:"SMTP_PORT, default=587"`
+	SMTPUser string `env:"SMTP_USER, required"`
+	SMTPPass string `env:"SMTP_PASS, required"`
+	SMTPCert string `env:"SMTP_CERT"`
+}
+
+// renderTemplate renders a template to string
+func renderTemplate(tmpl *template.Template, data map[string]interface{}) (string, error) {
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// sendMail sends email via SMTP
+func sendMail(
+	opts SMTPOptions,
+	sender string,
+	subject string,
+	body string,
+	recipients []string,
+) error {
+	if len(recipients) == 0 {
+		return nil
+	}
+
+	d := gomail.NewDialer(opts.SMTPHost, opts.SMTPPort, opts.SMTPUser, opts.SMTPPass)
+	if opts.SMTPCert != "" {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM([]byte(opts.SMTPCert))
+		d.TLSConfig = &tls.Config{
+			ServerName: opts.SMTPHost,
+			RootCAs:    pool,
+		}
+	}
+	s, err := d.Dial()
+	if err != nil {
+		return err
+	}
+
+	m := gomail.NewMessage()
+	m.SetHeaders(map[string][]string{
+		"From":    {sender},
+		"Subject": {subject},
+		"To":      recipients,
+	})
+	m.SetBody("text/html", body)
+	return gomail.Send(s, m)
+}

--- a/cmd/purge/mail_test.go
+++ b/cmd/purge/mail_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"html/template"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	notifyTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/notify.tmpl")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	purgeTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/purge.tmpl")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	testCases := map[string]struct {
+		tpl              *template.Template
+		data             map[string]interface{}
+		expectedErr      string
+		expectedTestFile string
+	}{
+		"constructs the appropriate notify template": {
+			tpl: notifyTemplate,
+			data: map[string]interface{}{
+				"org": &resource.Organization{
+					Name: "test-org",
+				},
+				"space": &resource.Space{
+					Name: "test-space",
+				},
+				"date": time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
+				"days": 90,
+			},
+			expectedTestFile: "../../testdata/notify.html",
+		},
+		"constructs the appropriate purge template": {
+			tpl: purgeTemplate,
+			data: map[string]interface{}{
+				"org": &resource.Organization{
+					Name: "test-org",
+				},
+				"space": &resource.Space{
+					Name: "test-space",
+				},
+				"date": time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
+				"days": 90,
+			},
+			expectedTestFile: "../../testdata/purge.html",
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			renderedTemplate, err := renderTemplate(
+				test.tpl,
+				test.data,
+			)
+			if (test.expectedErr == "" && err != nil) || (test.expectedErr != "" && test.expectedErr != err.Error()) {
+				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
+			}
+			if test.expectedTestFile != "" {
+				if os.Getenv("OVERRIDE_TEMPLATES") == "1" {
+					err := os.WriteFile(test.expectedTestFile, []byte(renderedTemplate), 0644)
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err)
+					}
+				}
+				expected, err := os.ReadFile(test.expectedTestFile)
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				if diff := cmp.Diff(string(expected), renderedTemplate); diff != "" {
+					t.Errorf("RenderTemplate() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -42,7 +42,7 @@ func main() {
 		log.Fatalf("error creating client: %s", err.Error())
 	}
 
-	orgs, err := ListSandboxOrgs(ctx, cfClient, opts.OrgPrefix)
+	orgs, err := listSandboxOrgs(ctx, cfClient, opts.OrgPrefix)
 	if err != nil {
 		log.Fatalf("error getting orgs: %s", err.Error())
 	}
@@ -73,12 +73,12 @@ func main() {
 
 	for _, org := range orgs {
 		log.Printf("getting org resources for org %s", org.Name)
-		spaces, apps, instances, err := ListOrgResources(ctx, cfClient, org)
+		spaces, apps, instances, err := listOrgResources(ctx, cfClient, org)
 		if err != nil {
 			log.Fatalf("error listing org resources for org %s: %s", org.Name, err.Error())
 		}
 
-		toNotify, toPurge, err := ListPurgeSpaces(spaces, apps, instances, now, opts.NotifyDays, opts.PurgeDays, timeStartsAt)
+		toNotify, toPurge, err := listPurgeSpaces(spaces, apps, instances, now, opts.NotifyDays, opts.PurgeDays, timeStartsAt)
 		if err != nil {
 			log.Fatalf("error listing spaces to purge for org %s: %s", org.Name, err.Error())
 		}

--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -83,9 +83,13 @@ func main() {
 			log.Fatalf("error listing spaces to purge for org %s: %s", org.Name, err.Error())
 		}
 
+		smtpMailer := &SMTPMailer{
+			options: opts.SMTPOptions,
+		}
+
 		log.Printf("notifying %d spaces in org %s", len(toNotify), org.Name)
 		for _, details := range toNotify {
-			err = notifySpaceUsers(ctx, cfClient, opts, userGUIDs, org, details)
+			err = notifySpaceUsers(ctx, cfClient, opts, userGUIDs, org, details, smtpMailer)
 			if err != nil {
 				log.Fatalf("error notifying space %s in org %s: %s", details.Space.Name, org.Name, err)
 			}
@@ -93,7 +97,7 @@ func main() {
 
 		log.Printf("purging %d spaces in org %s", len(toPurge), org.Name)
 		for _, details := range toPurge {
-			err = purgeAndRecreateSpace(ctx, cfClient, opts, userGUIDs, org, details)
+			err = purgeAndRecreateSpace(ctx, cfClient, opts, userGUIDs, org, details, smtpMailer)
 			if err != nil {
 				allPurgeErrors = append(allPurgeErrors, err.Error())
 			}

--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -83,13 +83,13 @@ func main() {
 			log.Fatalf("error listing spaces to purge for org %s: %s", org.Name, err.Error())
 		}
 
-		smtpMailer := &SMTPMailer{
+		mailSender := &smtpMailer{
 			options: opts.SMTPOptions,
 		}
 
 		log.Printf("notifying %d spaces in org %s", len(toNotify), org.Name)
 		for _, details := range toNotify {
-			err = notifySpaceUsers(ctx, cfClient, opts, userGUIDs, org, details, smtpMailer)
+			err = notifySpaceUsers(ctx, cfClient, opts, userGUIDs, org, details, mailSender)
 			if err != nil {
 				log.Fatalf("error notifying space %s in org %s: %s", details.Space.Name, org.Name, err)
 			}
@@ -97,7 +97,7 @@ func main() {
 
 		log.Printf("purging %d spaces in org %s", len(toPurge), org.Name)
 		for _, details := range toPurge {
-			err = purgeAndRecreateSpace(ctx, cfClient, opts, userGUIDs, org, details, smtpMailer)
+			err = purgeAndRecreateSpace(ctx, cfClient, opts, userGUIDs, org, details, mailSender)
 			if err != nil {
 				allPurgeErrors = append(allPurgeErrors, err.Error())
 			}

--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -92,13 +92,9 @@ func main() {
 			log.Fatalf("error listing spaces to purge for org %s: %s", org.Name, err.Error())
 		}
 
-		var (
-			recipients []string
-		)
-
 		log.Printf("notifying %d spaces in org %s", len(toNotify), org.Name)
 		for _, details := range toNotify {
-			recipients, err = notifySpaceUsers(ctx, cfClient, opts, userGUIDs, org, details)
+			err = notifySpaceUsers(ctx, cfClient, opts, userGUIDs, org, details)
 			if err != nil {
 				log.Fatalf("error notifying space %s in org %s: %s", details.Space.Name, org.Name, err)
 			}
@@ -106,8 +102,10 @@ func main() {
 
 		log.Printf("purging %d spaces in org %s", len(toPurge), org.Name)
 		for _, details := range toPurge {
-			purgeErrors := purgeSpace(ctx, cfClient, opts, userGUIDs, org, details, recipients)
-			allPurgeErrors = append(allPurgeErrors, purgeErrors...)
+			err = purgeSpace(ctx, cfClient, opts, userGUIDs, org, details)
+			if err != nil {
+				allPurgeErrors = append(allPurgeErrors, err.Error())
+			}
 		}
 	}
 

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -18,7 +18,7 @@ func notifySpaceUsers(
 	org *resource.Organization,
 	details SpaceDetails,
 ) error {
-	notifyTemplate, err := template.ParseFiles("./templates/base.html", "./templates/notify.tmpl")
+	notifyTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/notify.tmpl")
 	if err != nil {
 		return fmt.Errorf("error reading notify template: %w", err)
 	}

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -42,14 +42,14 @@ func notifySpaceUsers(
 			"days":  opts.PurgeDays,
 		}
 
-		body, err := RenderTemplate(notifyTemplate, data)
+		body, err := renderTemplate(notifyTemplate, data)
 		if err != nil {
 			return fmt.Errorf("error rendering email: %w", err)
 		}
 
 		log.Printf("sending to %s: %s", recipients, body)
 
-		if err := SendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
+		if err := sendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
 			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 		}
 	}

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"log"
+	"time"
+
+	"github.com/18f/cg-sandbox/sandbox"
+	"github.com/cloudfoundry-community/go-cfclient/v3/client"
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+)
+
+func notifySpaceUsers(
+	ctx context.Context,
+	cfClient *client.Client,
+	opts Options,
+	userGUIDs map[string]bool,
+	org *resource.Organization,
+	details sandbox.SpaceDetails,
+) ([]string, error) {
+	var recipients []string
+
+	notifyTemplate, err := template.ParseFiles("./templates/base.html", "./templates/notify.tmpl")
+	if err != nil {
+		return recipients, fmt.Errorf("error reading notify template: %w", err)
+	}
+
+	spaceUsers, err := cfClient.Spaces.ListUsersAll(ctx, details.Space.GUID, nil)
+	if err != nil {
+		return recipients, fmt.Errorf("error listing roles on space %s: %w", details.Space.Name, err)
+	}
+
+	recipients, err = sandbox.ListRecipients(userGUIDs, spaceUsers)
+	if err != nil {
+		return recipients, fmt.Errorf("error listing recipients on space %s: %w", details.Space.Name, err)
+	}
+
+	log.Printf("Notifying space %s; recipients %+v", details.Space.Name, recipients)
+	if !opts.DryRun {
+		data := map[string]interface{}{
+			"org":   org,
+			"space": details.Space,
+			"date":  details.Timestamp.Add(24 * time.Duration(opts.PurgeDays) * time.Hour),
+			"days":  opts.PurgeDays,
+		}
+
+		body, err := sandbox.RenderTemplate(notifyTemplate, data)
+		if err != nil {
+			return recipients, fmt.Errorf("error rendering email: %w", err)
+		}
+
+		log.Printf("sending to %s: %s", recipients, body)
+
+		if err := sandbox.SendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
+			return recipients, fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
+		}
+	}
+
+	return recipients, nil
+}

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -19,22 +19,20 @@ func notifySpaceUsers(
 	userGUIDs map[string]bool,
 	org *resource.Organization,
 	details sandbox.SpaceDetails,
-) ([]string, error) {
-	var recipients []string
-
+) error {
 	notifyTemplate, err := template.ParseFiles("./templates/base.html", "./templates/notify.tmpl")
 	if err != nil {
-		return recipients, fmt.Errorf("error reading notify template: %w", err)
+		return fmt.Errorf("error reading notify template: %w", err)
 	}
 
 	spaceUsers, err := cfClient.Spaces.ListUsersAll(ctx, details.Space.GUID, nil)
 	if err != nil {
-		return recipients, fmt.Errorf("error listing roles on space %s: %w", details.Space.Name, err)
+		return fmt.Errorf("error listing users on space %s: %w", details.Space.Name, err)
 	}
 
-	recipients, err = sandbox.ListRecipients(userGUIDs, spaceUsers)
+	recipients, err := sandbox.ListRecipients(userGUIDs, spaceUsers)
 	if err != nil {
-		return recipients, fmt.Errorf("error listing recipients on space %s: %w", details.Space.Name, err)
+		return fmt.Errorf("error listing recipients on space %s: %w", details.Space.Name, err)
 	}
 
 	log.Printf("Notifying space %s; recipients %+v", details.Space.Name, recipients)
@@ -48,15 +46,15 @@ func notifySpaceUsers(
 
 		body, err := sandbox.RenderTemplate(notifyTemplate, data)
 		if err != nil {
-			return recipients, fmt.Errorf("error rendering email: %w", err)
+			return fmt.Errorf("error rendering email: %w", err)
 		}
 
 		log.Printf("sending to %s: %s", recipients, body)
 
 		if err := sandbox.SendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
-			return recipients, fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
+			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 		}
 	}
 
-	return recipients, nil
+	return nil
 }

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -7,18 +7,16 @@ import (
 	"log"
 	"time"
 
-	"github.com/18f/cg-sandbox/sandbox"
-	"github.com/cloudfoundry-community/go-cfclient/v3/client"
 	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 )
 
 func notifySpaceUsers(
 	ctx context.Context,
-	cfClient *client.Client,
+	cfClient *cfResourceClient,
 	opts Options,
 	userGUIDs map[string]bool,
 	org *resource.Organization,
-	details sandbox.SpaceDetails,
+	details SpaceDetails,
 ) error {
 	notifyTemplate, err := template.ParseFiles("./templates/base.html", "./templates/notify.tmpl")
 	if err != nil {
@@ -30,7 +28,7 @@ func notifySpaceUsers(
 		return fmt.Errorf("error listing users on space %s: %w", details.Space.Name, err)
 	}
 
-	recipients, err := sandbox.ListRecipients(userGUIDs, spaceUsers)
+	recipients, err := ListRecipients(userGUIDs, spaceUsers)
 	if err != nil {
 		return fmt.Errorf("error listing recipients on space %s: %w", details.Space.Name, err)
 	}
@@ -44,14 +42,14 @@ func notifySpaceUsers(
 			"days":  opts.PurgeDays,
 		}
 
-		body, err := sandbox.RenderTemplate(notifyTemplate, data)
+		body, err := RenderTemplate(notifyTemplate, data)
 		if err != nil {
 			return fmt.Errorf("error rendering email: %w", err)
 		}
 
 		log.Printf("sending to %s: %s", recipients, body)
 
-		if err := sandbox.SendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
+		if err := SendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
 			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 		}
 	}

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -17,6 +17,7 @@ func notifySpaceUsers(
 	userGUIDs map[string]bool,
 	org *resource.Organization,
 	details SpaceDetails,
+	mailSender mailer,
 ) error {
 	notifyTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/notify.tmpl")
 	if err != nil {
@@ -49,7 +50,7 @@ func notifySpaceUsers(
 
 		log.Printf("sending to %s: %s", recipients, body)
 
-		if err := sendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
+		if err := mailSender.sendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
 			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 		}
 	}

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -35,24 +35,26 @@ func notifySpaceUsers(
 	}
 
 	log.Printf("Notifying space %s; recipients %+v", details.Space.Name, recipients)
-	if !opts.DryRun {
-		data := map[string]interface{}{
-			"org":   org,
-			"space": details.Space,
-			"date":  details.Timestamp.Add(24 * time.Duration(opts.PurgeDays) * time.Hour),
-			"days":  opts.PurgeDays,
-		}
+	if opts.DryRun {
+		return nil
+	}
 
-		body, err := renderTemplate(notifyTemplate, data)
-		if err != nil {
-			return fmt.Errorf("error rendering email: %w", err)
-		}
+	data := map[string]interface{}{
+		"org":   org,
+		"space": details.Space,
+		"date":  details.Timestamp.Add(24 * time.Duration(opts.PurgeDays) * time.Hour),
+		"days":  opts.PurgeDays,
+	}
 
-		log.Printf("sending to %s: %s", recipients, body)
+	body, err := renderTemplate(notifyTemplate, data)
+	if err != nil {
+		return fmt.Errorf("error rendering email: %w", err)
+	}
 
-		if err := mailSender.sendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
-			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
-		}
+	log.Printf("sending to %s: %s", recipients, body)
+
+	if err := mailSender.sendMail(opts.SMTPOptions, opts.MailSender, opts.NotifyMailSubject, body, recipients); err != nil {
+		return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 	}
 
 	return nil

--- a/cmd/purge/notify.go
+++ b/cmd/purge/notify.go
@@ -28,7 +28,7 @@ func notifySpaceUsers(
 		return fmt.Errorf("error listing users on space %s: %w", details.Space.Name, err)
 	}
 
-	recipients, err := ListRecipients(userGUIDs, spaceUsers)
+	recipients, err := listRecipients(userGUIDs, spaceUsers)
 	if err != nil {
 		return fmt.Errorf("error listing recipients on space %s: %w", details.Space.Name, err)
 	}

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -52,13 +52,13 @@ func purgeAndRecreateSpace(
 			"space": details.Space,
 			"days":  opts.PurgeDays,
 		}
-		body, err := RenderTemplate(purgeTemplate, data)
+		body, err := renderTemplate(purgeTemplate, data)
 		if err != nil {
 			log.Fatalf("error rendering email: %s", err.Error())
 		}
 
 		log.Printf("sending to %s: %s", recipients, body)
-		if err := SendMail(opts.SMTPOptions, opts.MailSender, opts.PurgeMailSubject, body, recipients); err != nil {
+		if err := sendMail(opts.SMTPOptions, opts.MailSender, opts.PurgeMailSubject, body, recipients); err != nil {
 			log.Fatalf("error sending mail on space %s: %s", details.Space.Name, err.Error())
 		}
 

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -18,9 +18,9 @@ func purgeAndRecreateSpace(
 	org *resource.Organization,
 	details SpaceDetails,
 ) error {
-	purgeTemplate, err := template.ParseFiles("./templates/base.html", "./templates/purge.tmpl")
+	purgeTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/purge.tmpl")
 	if err != nil {
-		log.Fatalf("error reading purge template: %s", err.Error())
+		return fmt.Errorf("error reading purge template: %s", err)
 	}
 
 	spaceRoles, err := cfClient.Roles.ListAll(ctx, &client.RoleListOptions{
@@ -30,7 +30,7 @@ func purgeAndRecreateSpace(
 		Include: resource.RoleIncludeUser,
 	})
 	if err != nil {
-		log.Fatalf("error listing roles on space %s: %s", details.Space.Name, err.Error())
+		return fmt.Errorf("error listing roles on space %s: %w", details.Space.Name, err)
 	}
 
 	spaceUsers, err := cfClient.Spaces.ListUsersAll(ctx, details.Space.GUID, nil)
@@ -54,12 +54,12 @@ func purgeAndRecreateSpace(
 		}
 		body, err := renderTemplate(purgeTemplate, data)
 		if err != nil {
-			log.Fatalf("error rendering email: %s", err.Error())
+			return fmt.Errorf("error rendering email: %s", err)
 		}
 
 		log.Printf("sending to %s: %s", recipients, body)
 		if err := sendMail(opts.SMTPOptions, opts.MailSender, opts.PurgeMailSubject, body, recipients); err != nil {
-			log.Fatalf("error sending mail on space %s: %s", details.Space.Name, err.Error())
+			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 		}
 
 		log.Printf("deleting and recreating space %s", details.Space.Name)

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -38,12 +38,12 @@ func purgeAndRecreateSpace(
 		return fmt.Errorf("error listing users on space %s: %w", details.Space.Name, err)
 	}
 
-	recipients, err := ListRecipients(userGUIDs, spaceUsers)
+	recipients, err := listRecipients(userGUIDs, spaceUsers)
 	if err != nil {
 		return fmt.Errorf("error listing recipients on space %s: %w", details.Space.Name, err)
 	}
 
-	developers, managers := ListSpaceDevsAndManagers(userGUIDs, spaceRoles)
+	developers, managers := listSpaceDevsAndManagers(userGUIDs, spaceRoles)
 	log.Printf("Purging space %s; recipients: %+v, developers: %+v, managers: %+v", details.Space.Name, recipients, developers, managers)
 
 	if !opts.DryRun {
@@ -63,7 +63,7 @@ func purgeAndRecreateSpace(
 		}
 
 		log.Printf("deleting and recreating space %s", details.Space.Name)
-		if err := PurgeSpace(ctx, cfClient, details.Space); err != nil {
+		if err := purgeSpace(ctx, cfClient, details.Space); err != nil {
 			return fmt.Errorf("error purging space %s in org %s: %w", details.Space.Name, org.Name, err)
 		}
 
@@ -77,7 +77,7 @@ func purgeAndRecreateSpace(
 				return fmt.Errorf("error recreating space %s in org %s: %w", details.Space.Name, org.Name, err)
 			}
 			log.Printf("recreating space roles")
-			if err := RecreateSpaceDevsAndManagers(ctx, cfClient, details.Space.GUID, developers, managers); err != nil {
+			if err := recreateSpaceDevsAndManagers(ctx, cfClient, details.Space.GUID, developers, managers); err != nil {
 				return fmt.Errorf("error recreating space developers/managers for space %s in org %s: %w", details.Space.Name, org.Name, err)
 			}
 		}

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -17,12 +17,8 @@ func purgeAndRecreateSpace(
 	userGUIDs map[string]bool,
 	org *resource.Organization,
 	details SpaceDetails,
+	mailSender mailer,
 ) error {
-	purgeTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/purge.tmpl")
-	if err != nil {
-		return fmt.Errorf("error reading purge template: %s", err)
-	}
-
 	spaceRoles, err := cfClient.Roles.ListAll(ctx, &client.RoleListOptions{
 		SpaceGUIDs: client.Filter{
 			Values: []string{details.Space.GUID},
@@ -47,19 +43,8 @@ func purgeAndRecreateSpace(
 	log.Printf("Purging space %s; recipients: %+v, developers: %+v, managers: %+v", details.Space.Name, recipients, developers, managers)
 
 	if !opts.DryRun {
-		data := map[string]interface{}{
-			"org":   org,
-			"space": details.Space,
-			"days":  opts.PurgeDays,
-		}
-		body, err := renderTemplate(purgeTemplate, data)
-		if err != nil {
-			return fmt.Errorf("error rendering email: %s", err)
-		}
-
-		log.Printf("sending to %s: %s", recipients, body)
-		if err := sendMail(opts.SMTPOptions, opts.MailSender, opts.PurgeMailSubject, body, recipients); err != nil {
-			return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
+		if err := sendPurgeEmail(ctx, cfClient, opts, org, details, recipients, mailSender); err != nil {
+			return fmt.Errorf("error sending purge notification email for space %s in org %s: %w", details.Space.Name, org.Name, err)
 		}
 
 		log.Printf("deleting and recreating space %s", details.Space.Name)
@@ -81,6 +66,38 @@ func purgeAndRecreateSpace(
 				return fmt.Errorf("error recreating space developers/managers for space %s in org %s: %w", details.Space.Name, org.Name, err)
 			}
 		}
+	}
+
+	return nil
+}
+
+func sendPurgeEmail(
+	ctx context.Context,
+	cfClient *cfResourceClient,
+	opts Options,
+	org *resource.Organization,
+	details SpaceDetails,
+	recipients []string,
+	mailSender mailer,
+) error {
+	purgeTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/purge.tmpl")
+	if err != nil {
+		return fmt.Errorf("error reading purge template: %s", err)
+	}
+
+	data := map[string]interface{}{
+		"org":   org,
+		"space": details.Space,
+		"days":  opts.PurgeDays,
+	}
+	body, err := renderTemplate(purgeTemplate, data)
+	if err != nil {
+		return fmt.Errorf("error rendering email: %s", err)
+	}
+
+	log.Printf("sending to %s: %s", recipients, body)
+	if err := mailSender.sendMail(opts.SMTPOptions, opts.MailSender, opts.PurgeMailSubject, body, recipients); err != nil {
+		return fmt.Errorf("error sending mail on space %s: %w", details.Space.Name, err)
 	}
 
 	return nil

--- a/cmd/purge/purge_test.go
+++ b/cmd/purge/purge_test.go
@@ -89,6 +89,18 @@ func (s *mockSpaces) Delete(ctx context.Context, guid string) (string, error) {
 	return "", nil
 }
 
+type mockMailSender struct{}
+
+func (m *mockMailSender) sendMail(
+	opts SMTPOptions,
+	sender string,
+	subject string,
+	body string,
+	recipients []string,
+) error {
+	return nil
+}
+
 func TestPurgeAndRecreateSpace(t *testing.T) {
 	userGUIDs := map[string]bool{
 		"user-1": true,
@@ -133,13 +145,14 @@ func TestPurgeAndRecreateSpace(t *testing.T) {
 		},
 		userGUIDs,
 		&resource.Organization{
-			Name: "foobar",
+			GUID: "org-1",
 		},
 		SpaceDetails{
 			Space: &resource.Space{
 				GUID: "space-1",
 			},
 		},
+		&mockMailSender{},
 	)
 
 	if err != nil {

--- a/cmd/purge/purge_test.go
+++ b/cmd/purge/purge_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cloudfoundry-community/go-cfclient/v3/client"
+	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockApplications struct {
+	listAppsErr error
+	apps        []*resource.App
+	spaceGUID   string
+}
+
+func (a *mockApplications) ListAll(ctx context.Context, opts *client.AppListOptions) ([]*resource.App, error) {
+	if a.listAppsErr != nil {
+		return nil, a.listAppsErr
+	}
+	expectedOpts := &client.AppListOptions{
+		SpaceGUIDs: client.Filter{
+			Values: []string{a.spaceGUID},
+		},
+	}
+	if !cmp.Equal(opts, expectedOpts) {
+		return nil, fmt.Errorf(cmp.Diff(opts, expectedOpts))
+	}
+	return a.apps, nil
+}
+
+func (a *mockApplications) Delete(ctx context.Context, guid string) (string, error) {
+	return "", nil
+}
+
+type mockRoles struct {
+	listRolesErr error
+	roles        []*resource.Role
+	spaceGUID    string
+}
+
+func (r *mockRoles) CreateSpaceRole(ctx context.Context, spaceGUID, userGUID string, roleType resource.SpaceRoleType) (*resource.Role, error) {
+	return nil, nil
+}
+
+func (r *mockRoles) ListAll(ctx context.Context, opts *client.RoleListOptions) ([]*resource.Role, error) {
+	if r.listRolesErr != nil {
+		return nil, r.listRolesErr
+	}
+	expectedOpts := &client.RoleListOptions{
+		SpaceGUIDs: client.Filter{
+			Values: []string{r.spaceGUID},
+		},
+		Include: resource.RoleIncludeUser,
+	}
+	if !cmp.Equal(opts, expectedOpts) {
+		return nil, fmt.Errorf(cmp.Diff(opts, expectedOpts))
+	}
+	return r.roles, nil
+}
+
+type mockSpaces struct {
+	listUsersAllErr error
+	users           []*resource.User
+	spaceGUID       string
+}
+
+func (s *mockSpaces) ListUsersAll(ctx context.Context, spaceGUID string, opts *client.UserListOptions) ([]*resource.User, error) {
+	if s.listUsersAllErr != nil {
+		return nil, s.listUsersAllErr
+	}
+	if spaceGUID != s.spaceGUID {
+		return nil, fmt.Errorf("expected %s, got %s", spaceGUID, s.spaceGUID)
+	}
+	return s.users, nil
+}
+
+func (s *mockSpaces) ListAll(ctx context.Context, opts *client.SpaceListOptions) ([]*resource.Space, error) {
+	return nil, nil
+}
+
+func (s *mockSpaces) Create(ctx context.Context, r *resource.SpaceCreate) (*resource.Space, error) {
+	return nil, nil
+}
+
+func (s *mockSpaces) Delete(ctx context.Context, guid string) (string, error) {
+	return "", nil
+}
+
+func TestPurgeAndRecreateSpace(t *testing.T) {
+	userGUIDs := map[string]bool{
+		"user-1": true,
+	}
+
+	err := purgeAndRecreateSpace(
+		context.Background(),
+		&cfResourceClient{
+			Applications: &mockApplications{},
+			Roles: &mockRoles{
+				spaceGUID: "space-1",
+				roles: []*resource.Role{
+					{
+						Type: resource.SpaceRoleManager.String(),
+						Relationships: resource.RoleSpaceUserOrganizationRelationships{
+							Space: resource.ToOneRelationship{
+								Data: &resource.Relationship{
+									GUID: "space-1",
+								},
+							},
+							User: resource.ToOneRelationship{
+								Data: &resource.Relationship{
+									GUID: "user-1",
+								},
+							},
+						},
+					},
+				},
+			},
+			Spaces: &mockSpaces{
+				spaceGUID: "space-1",
+				users: []*resource.User{
+					{
+						GUID:     "user-1",
+						Username: "foo@bar.gov",
+					},
+				},
+			},
+		},
+		Options{
+			DryRun: false,
+		},
+		userGUIDs,
+		&resource.Organization{
+			Name: "foobar",
+		},
+		SpaceDetails{
+			Space: &resource.Space{
+				GUID: "space-1",
+			},
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -1,4 +1,4 @@
-package sandbox
+package main
 
 import (
 	"bytes"
@@ -65,7 +65,7 @@ func ListSpaceDevsAndManagers(
 
 func RecreateSpaceDevsAndManagers(
 	ctx context.Context,
-	cfClient *client.Client,
+	cfClient *cfResourceClient,
 	spaceGUID string,
 	developers []string,
 	managers []string,
@@ -86,7 +86,11 @@ func RecreateSpaceDevsAndManagers(
 }
 
 // PurgeSpace deletes a space; if the delete fails, it deletes all applications within the space
-func PurgeSpace(ctx context.Context, cfClient *client.Client, space *resource.Space) error {
+func PurgeSpace(
+	ctx context.Context,
+	cfClient *cfResourceClient,
+	space *resource.Space,
+) error {
 	_, spaceErr := cfClient.Spaces.Delete(ctx, space.GUID)
 	if spaceErr != nil {
 		apps, err := cfClient.Applications.ListAll(ctx, &client.AppListOptions{
@@ -156,12 +160,12 @@ func SendMail(
 // ListSandboxOrgs lists all sandbox organizations
 func ListSandboxOrgs(
 	ctx context.Context,
-	client *client.Client,
+	cfClient *cfResourceClient,
 	prefix string,
 ) ([]*resource.Organization, error) {
 	sandboxes := []*resource.Organization{}
 
-	orgs, err := client.Organizations.ListAll(ctx, nil)
+	orgs, err := cfClient.Organizations.ListAll(ctx, nil)
 	if err != nil {
 		return sandboxes, err
 	}
@@ -178,7 +182,7 @@ func ListSandboxOrgs(
 // ListOrgResources fetches apps, service instances, and spaces within an organization
 func ListOrgResources(
 	ctx context.Context,
-	cfClient *client.Client,
+	cfClient *cfResourceClient,
 	org *resource.Organization,
 ) (
 	spaces []*resource.Space,

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cloudfoundry-community/go-cfclient/v3/resource"
 )
 
-// ListRecipients get a list of recipient emails from space users
-func ListRecipients(
+// listRecipients get a list of recipient emails from space users
+func listRecipients(
 	userGUIDs map[string]bool,
 	spaceUsers []*resource.User,
 ) (addresses []string, err error) {
@@ -29,7 +29,7 @@ func ListRecipients(
 	return addresses, nil
 }
 
-func ListSpaceDevsAndManagers(
+func listSpaceDevsAndManagers(
 	userGUIDs map[string]bool,
 	spaceRoles []*resource.Role,
 ) (developers []string, managers []string) {
@@ -49,7 +49,7 @@ func ListSpaceDevsAndManagers(
 	return
 }
 
-func RecreateSpaceDevsAndManagers(
+func recreateSpaceDevsAndManagers(
 	ctx context.Context,
 	cfClient *cfResourceClient,
 	spaceGUID string,
@@ -71,8 +71,8 @@ func RecreateSpaceDevsAndManagers(
 	return nil
 }
 
-// PurgeSpace deletes a space; if the delete fails, it deletes all applications within the space
-func PurgeSpace(
+// purgeSpace deletes a space; if the delete fails, it deletes all applications within the space
+func purgeSpace(
 	ctx context.Context,
 	cfClient *cfResourceClient,
 	space *resource.Space,
@@ -98,8 +98,8 @@ func PurgeSpace(
 	return nil
 }
 
-// ListSandboxOrgs lists all sandbox organizations
-func ListSandboxOrgs(
+// listSandboxOrgs lists all sandbox organizations
+func listSandboxOrgs(
 	ctx context.Context,
 	cfClient *cfResourceClient,
 	prefix string,
@@ -120,8 +120,8 @@ func ListSandboxOrgs(
 	return sandboxes, nil
 }
 
-// ListOrgResources fetches apps, service instances, and spaces within an organization
-func ListOrgResources(
+// listOrgResources fetches apps, service instances, and spaces within an organization
+func listOrgResources(
 	ctx context.Context,
 	cfClient *cfResourceClient,
 	org *resource.Organization,
@@ -155,8 +155,8 @@ func ListOrgResources(
 	return
 }
 
-// GetFirstResource gets the creation timestamp of the earliest-created resource in a space
-func GetFirstResource(
+// letFirstResource gets the creation timestamp of the earliest-created resource in a space
+func letFirstResource(
 	space *resource.Space,
 	apps []*resource.App,
 	instances []*resource.ServiceInstance,
@@ -185,8 +185,8 @@ type SpaceDetails struct {
 	Space     *resource.Space
 }
 
-// ListPurgeSpaces identifies spaces that will be notified or purged
-func ListPurgeSpaces(
+// listPurgeSpaces identifies spaces that will be notified or purged
+func listPurgeSpaces(
 	spaces []*resource.Space,
 	apps []*resource.App,
 	instances []*resource.ServiceInstance,
@@ -201,7 +201,7 @@ func ListPurgeSpaces(
 ) {
 	var firstResource time.Time
 	for _, space := range spaces {
-		firstResource, err = GetFirstResource(space, apps, instances)
+		firstResource, err = letFirstResource(space, apps, instances)
 		if err != nil {
 			return
 		}

--- a/cmd/purge/sandbox_test.go
+++ b/cmd/purge/sandbox_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"html/template"
-	"os"
 	"testing"
 	"time"
 
@@ -476,80 +474,6 @@ func TestGetFirstResource(t *testing.T) {
 			}
 			if !cmp.Equal(test.expectedFirstResource, firstResource) {
 				t.Errorf("GetFirstResource() expected: %s, got: %s", test.expectedFirstResource, firstResource)
-			}
-		})
-	}
-}
-
-func TestRenderTemplate(t *testing.T) {
-	notifyTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/notify.tmpl")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	purgeTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/purge.tmpl")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	testCases := map[string]struct {
-		tpl              *template.Template
-		data             map[string]interface{}
-		expectedErr      string
-		expectedTestFile string
-	}{
-		"constructs the appropriate notify template": {
-			tpl: notifyTemplate,
-			data: map[string]interface{}{
-				"org": &resource.Organization{
-					Name: "test-org",
-				},
-				"space": &resource.Space{
-					Name: "test-space",
-				},
-				"date": time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
-				"days": 90,
-			},
-			expectedTestFile: "../../testdata/notify.html",
-		},
-		"constructs the appropriate purge template": {
-			tpl: purgeTemplate,
-			data: map[string]interface{}{
-				"org": &resource.Organization{
-					Name: "test-org",
-				},
-				"space": &resource.Space{
-					Name: "test-space",
-				},
-				"date": time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
-				"days": 90,
-			},
-			expectedTestFile: "../../testdata/purge.html",
-		},
-	}
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			renderedTemplate, err := RenderTemplate(
-				test.tpl,
-				test.data,
-			)
-			if (test.expectedErr == "" && err != nil) || (test.expectedErr != "" && test.expectedErr != err.Error()) {
-				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
-			}
-			if test.expectedTestFile != "" {
-				if os.Getenv("OVERRIDE_TEMPLATES") == "1" {
-					err := os.WriteFile(test.expectedTestFile, []byte(renderedTemplate), 0644)
-					if err != nil {
-						t.Fatalf("unexpected error: %s", err)
-					}
-				}
-				expected, err := os.ReadFile(test.expectedTestFile)
-				if err != nil {
-					t.Fatalf("unexpected error: %s", err)
-				}
-				if diff := cmp.Diff(string(expected), renderedTemplate); diff != "" {
-					t.Errorf("RenderTemplate() mismatch (-want +got):\n%s", diff)
-				}
 			}
 		})
 	}

--- a/cmd/purge/sandbox_test.go
+++ b/cmd/purge/sandbox_test.go
@@ -1,4 +1,4 @@
-package sandbox
+package main
 
 import (
 	"html/template"
@@ -482,12 +482,12 @@ func TestGetFirstResource(t *testing.T) {
 }
 
 func TestRenderTemplate(t *testing.T) {
-	notifyTemplate, err := template.ParseFiles("../templates/base.html", "../templates/notify.tmpl")
+	notifyTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/notify.tmpl")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	purgeTemplate, err := template.ParseFiles("../templates/base.html", "../templates/purge.tmpl")
+	purgeTemplate, err := template.ParseFiles("../../templates/base.html", "../../templates/purge.tmpl")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -510,7 +510,7 @@ func TestRenderTemplate(t *testing.T) {
 				"date": time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
 				"days": 90,
 			},
-			expectedTestFile: "../testdata/notify.html",
+			expectedTestFile: "../../testdata/notify.html",
 		},
 		"constructs the appropriate purge template": {
 			tpl: purgeTemplate,
@@ -524,7 +524,7 @@ func TestRenderTemplate(t *testing.T) {
 				"date": time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC),
 				"days": 90,
 			},
-			expectedTestFile: "../testdata/purge.html",
+			expectedTestFile: "../../testdata/purge.html",
 		},
 	}
 	for name, test := range testCases {

--- a/cmd/purge/sandbox_test.go
+++ b/cmd/purge/sandbox_test.go
@@ -39,7 +39,7 @@ func TestListRecipients(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			recipients, err := ListRecipients(test.userGUIDs, test.users)
+			recipients, err := listRecipients(test.userGUIDs, test.users)
 			if (test.expectedErr == "" && err != nil) || (test.expectedErr != "" && test.expectedErr != err.Error()) {
 				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
 			}
@@ -130,7 +130,7 @@ func TestListSpaceDevsAndManagers(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			devs, managers := ListSpaceDevsAndManagers(test.userGUIDs, test.roles)
+			devs, managers := listSpaceDevsAndManagers(test.userGUIDs, test.roles)
 			if diff := cmp.Diff(test.expectedDevs, devs); diff != "" {
 				t.Errorf("ListSpaceDevsAndManagers() mismatch (-want +got):\n%s", diff)
 			}
@@ -361,7 +361,7 @@ func TestListPurgeSpaces(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			toNotify, toPurge, err := ListPurgeSpaces(
+			toNotify, toPurge, err := listPurgeSpaces(
 				test.spaces,
 				test.apps,
 				test.instances,
@@ -464,7 +464,7 @@ func TestGetFirstResource(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			firstResource, err := GetFirstResource(
+			firstResource, err := letFirstResource(
 				test.space,
 				test.apps,
 				test.instances,


### PR DESCRIPTION
## Changes proposed in this pull request:

- This PR refactors the code extensively to add interfaces and structs for testing
- Remove the separate `sandbox` package which seemed unnecessary and made testing more difficult
- Make everything private by default
- Add unit test for purge functionality
- Update code so that recipients for notifications and purge are retrieved separately. Current code had a bug where the recipients from the last notified space would be using when purging spaces in the same org

## security considerations

None, just refactoring code for testability and maintenance
