### PR TITLE
Fix CI script

### DIFF
--- a/ci/purge.sh
+++ b/ci/purge.sh
@@ -7,4 +7,6 @@ export PATH=$PATH:$GOPATH/bin
 
 cd gopath/src/github.com/18F/cg-sandbox
 
-go run cmd/purge/main.go
+cd cmd/purge
+
+go run .


### PR DESCRIPTION
## Changes proposed in this pull request:

Apparently, if you multiple files in the `main` package and you execute the program via `go run main.go`, then Go only recognizes the contents of `main.go` and not the code in any other `*.go` files. See https://stackoverflow.com/questions/28081486/how-can-i-go-run-a-project-with-multiple-files-in-the-main-package.

To fix this, you can use `go run .` to invoke your program including all the files in the `main` package, which is what I have done in this PR. 

An alternate solution would probably have been to create a subpackage here, maybe named `purge`, and import that from `main.go`. Then `go run main.go` would still have worked properly. But given the small size and scope of this program, a separate subpackage seemed unnecessary.

## security considerations

None, just updating command to invoke the program in CI
