### PR TITLE
Add disable purge logic

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -117,7 +117,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: https://github.com/cloud-gov/cg-sandbox
-    branch: main
+    branch: fix-go-mod
 
 - name: schedule
   type: cron-resource

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -131,7 +131,7 @@ resources:
   source:
     commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: https://github.com/cloud-gov/cg-sandbox
-    branch: fix-go-mod
+    branch: main
 
 - name: schedule
   type: cron-resource

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -18,6 +18,23 @@ jobs:
   - task: test
     image: general-task
     file: sandbox-source/ci/test.yml
+  on_failure:
+    put: slack
+    params: &slack-failure-params
+      text: |
+        :x: Tests FAILED on purge-sandboxes
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel-failure))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+  on_success:
+    put: slack
+    params: &slack-success-params
+      <<: *slack-failure-params
+      channel: ((slack-channel-success))
+      text: |
+        :white_check_mark: Tests PASSED on purge-sandboxes
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 - name: purge-sandboxes-staging
   plan:
@@ -48,20 +65,18 @@ jobs:
       MAIL_SENDER: ((smtp-from))
       TIME_STARTS_AT: ((time-starts-at-staging))
       DRY_RUN: ((dry-run-staging))
+      DISABLE_PURGE: ((disable-purge-staging))
   on_failure:
     put: slack
-    params: &slack-params
+    params:
+      <<: *slack-failure-params
       text: |
         :x: FAILED to notify sandbox users on staging
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel-failure))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
   on_success:
     put: slack
     params:
-      <<: *slack-params
-      channel: ((slack-channel-success))
+      <<: *slack-success-params
       text: |
         :white_check_mark: Successfully notified sandbox users on staging
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
@@ -94,19 +109,18 @@ jobs:
       MAIL_SENDER: ((smtp-from))
       TIME_STARTS_AT: ((time-starts-at-production))
       DRY_RUN: ((dry-run-production))
+      DISABLE_PURGE: ((disable-purge-production))
   on_failure:
     put: slack
     params:
-      <<: *slack-params
-      channel: ((slack-channel-failure))
+      <<: *slack-failure-params
       text: |
         :x: FAILED to notify sandbox users on production
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
   on_success:
     put: slack
     params:
-      <<: *slack-params
-      channel: ((slack-channel-success))
+      <<: *slack-success-params
       text: |
         :white_check_mark: Successfully notified sandbox users on production
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>

--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -22,6 +22,7 @@ type Options struct {
 	PurgeMailSubject  string `env:"PURGE_MAIL_SUBJECT, required"`
 	DryRun            bool   `env:"DRY_RUN, default=true"`
 	TimeStartsAt      string `env:"TIME_STARTS_AT"`
+	DisablePurge      bool   `env:"DISABLE_PURGE, default=false"`
 	SMTPOptions
 }
 
@@ -78,7 +79,7 @@ func main() {
 			log.Fatalf("error listing org resources for org %s: %s", org.Name, err.Error())
 		}
 
-		toNotify, toPurge, err := listPurgeSpaces(spaces, apps, instances, now, opts.NotifyDays, opts.PurgeDays, timeStartsAt)
+		toNotify, toPurge, err := listPurgeSpaces(spaces, apps, instances, opts, now, timeStartsAt)
 		if err != nil {
 			log.Fatalf("error listing spaces to purge for org %s: %s", org.Name, err.Error())
 		}

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -215,9 +215,8 @@ func listPurgeSpaces(
 	spaces []*resource.Space,
 	apps []*resource.App,
 	instances []*resource.ServiceInstance,
+	opts Options,
 	now time.Time,
-	notifyThreshold int,
-	purgeThreshold int,
 	timeStartsAt time.Time,
 ) (
 	toNotify []SpaceDetails,
@@ -239,9 +238,9 @@ func listPurgeSpaces(
 
 		firstResource := firstResource.Truncate(24 * time.Hour)
 		delta := int(now.Sub(firstResource).Hours() / 24)
-		if delta >= purgeThreshold {
+		if !opts.DisablePurge && delta >= opts.PurgeDays {
 			toPurge = append(toPurge, SpaceDetails{firstResource, space})
-		} else if delta >= notifyThreshold {
+		} else if delta >= opts.NotifyDays {
 			toNotify = append(toNotify, SpaceDetails{firstResource, space})
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/18f/cg-sandbox
 
-go 1.20
+go 1.22
 
 require (
 	github.com/cloudfoundry-community/go-cfclient/v3 v3.0.0-alpha.6


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update go.mod to 1.22. Fixes #43 
- Add option to allow disabling purge behavior. This flag is helpful because the purge sandboxes pipeline in production has been broken or disabled for a while. So we want to be very sure that our customers receive notifications that their sandboxes will be purged before they actually purged, which these changes accomplish
- Added unit tests for new behavior
- Updated pipeline to notify on failed unit tests

## security considerations

No security changes, just maintenance and adding more flags for behavior
