### PR TITLE
Fix space recreation

### DIFF
--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -52,8 +52,7 @@ func purgeAndRecreateSpace(
 			Name:          details.Space.Name,
 			Relationships: details.Space.Relationships,
 		}
-		log.Printf("recreating space: %+v", spaceRequest)
-		if _, err := cfClient.Spaces.Create(ctx, &resource.SpaceCreate{}); err != nil {
+		if _, err := cfClient.Spaces.Create(ctx, spaceRequest); err != nil {
 			return fmt.Errorf("error recreating space %s in org %s: %w", details.Space.Name, org.Name, err)
 		}
 		log.Printf("recreating space roles")

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -32,7 +32,7 @@ func purgeAndRecreateSpace(
 	}
 
 	developers, managers := listSpaceDevsAndManagers(userGUIDs, spaceRoles, spaceUsers)
-	log.Printf("Purging space %s; recipients: %+v, developers: %+v, managers: %+v", details.Space.Name, recipients, developers, managers)
+	log.Printf("Purging space %s; recipients: %+v", details.Space.Name, recipients)
 
 	if opts.DryRun {
 		return nil

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -38,7 +38,7 @@ func purgeAndRecreateSpace(
 		return nil
 	}
 
-	if err := sendPurgeEmail(ctx, cfClient, opts, org, details, recipients, mailSender); err != nil {
+	if err := sendPurgeEmail(opts, org, details, recipients, mailSender); err != nil {
 		return fmt.Errorf("error sending purge notification email for space %s in org %s: %w", details.Space.Name, org.Name, err)
 	}
 
@@ -65,8 +65,6 @@ func purgeAndRecreateSpace(
 }
 
 func sendPurgeEmail(
-	ctx context.Context,
-	cfClient *cfResourceClient,
 	opts Options,
 	org *resource.Organization,
 	details SpaceDetails,

--- a/cmd/purge/sandbox_test.go
+++ b/cmd/purge/sandbox_test.go
@@ -55,8 +55,8 @@ func TestListSpaceDevsAndManagers(t *testing.T) {
 		userGUIDs        map[string]bool
 		roles            []*resource.Role
 		users            []*resource.User
-		expectedDevs     []string
-		expectedManagers []string
+		expectedDevs     []spaceUser
+		expectedManagers []spaceUser
 		expectedErr      string
 	}{
 		"returns correct devs and managers": {
@@ -106,8 +106,22 @@ func TestListSpaceDevsAndManagers(t *testing.T) {
 					},
 				},
 			},
-			expectedDevs:     []string{"foo1@bar.gov", "foo2@bar.gov"},
-			expectedManagers: []string{"foo1@bar.gov"},
+			expectedDevs: []spaceUser{
+				{
+					GUID:     "user-1",
+					Username: "foo1@bar.gov",
+				},
+				{
+					GUID:     "user-2",
+					Username: "foo2@bar.gov",
+				},
+			},
+			expectedManagers: []spaceUser{
+				{
+					GUID:     "user-1",
+					Username: "foo1@bar.gov",
+				},
+			},
 		},
 		"skips users not in user GUIDs map": {
 			userGUIDs: map[string]bool{
@@ -145,8 +159,13 @@ func TestListSpaceDevsAndManagers(t *testing.T) {
 					},
 				},
 			},
-			expectedDevs:     []string{"foo1@bar.gov"},
-			expectedManagers: []string{},
+			expectedDevs: []spaceUser{
+				{
+					GUID:     "user-1",
+					Username: "foo1@bar.gov",
+				},
+			},
+			expectedManagers: []spaceUser{},
 		},
 		"skips users without username": {
 			userGUIDs: map[string]bool{
@@ -181,8 +200,13 @@ func TestListSpaceDevsAndManagers(t *testing.T) {
 					},
 				},
 			},
-			expectedDevs:     []string{"foo1@bar.gov"},
-			expectedManagers: []string{},
+			expectedDevs: []spaceUser{
+				{
+					GUID:     "user-1",
+					Username: "foo1@bar.gov",
+				},
+			},
+			expectedManagers: []spaceUser{},
 		},
 	}
 	for name, test := range testCases {


### PR DESCRIPTION
## Changes proposed in this pull request:

Fixes #46

- Fix bad logic which was not passing the actual `spaceRequest` struct to recreate a sandbox space after purging it
- Fix logic for recreating space devs and managers which was incorrectly passing the username and not the user GUID
- Add/improve unit tests for above behavior

## security considerations

No direct security considerations other than any concerns we have about what this code logs and is printed in our CI environment logs. Though our CI environments logs are not centralized anywhere and are only available to platform operators.
