### PR TITLE
Handle quota recreation

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -48,7 +48,7 @@ jobs:
   - task: purge
     file: sandbox-source/ci/purge.yml
     image: general-task
-    params:
+    params: &purge-params
       API_ADDRESS: ((staging-cf-api-url))
       CLIENT_ID: ((client-id-staging))
       CLIENT_SECRET: ((client-secret-staging))
@@ -66,6 +66,7 @@ jobs:
       TIME_STARTS_AT: ((time-starts-at-staging))
       DRY_RUN: ((dry-run-staging))
       DISABLE_PURGE: ((disable-purge-staging))
+      SANDBOX_QUOTA_NAME: ((sandbox-quota-name))
   on_failure:
     put: slack
     params:
@@ -93,20 +94,10 @@ jobs:
     file: sandbox-source/ci/purge.yml
     image: general-task
     params:
+      <<: *purge-params
       API_ADDRESS: ((prod-cf-api-url))
       CLIENT_ID: ((client-id-production))
       CLIENT_SECRET: ((client-secret-production))
-      ORG_PREFIX: ((org-prefix))
-      NOTIFY_DAYS: ((notify-days))
-      PURGE_DAYS: ((purge-days))
-      NOTIFY_MAIL_SUBJECT: ((notify-subject))
-      PURGE_MAIL_SUBJECT: ((purge-subject))
-      SMTP_HOST: ((smtp-host))
-      SMTP_USER: ((smtp-user))
-      SMTP_PASS: ((smtp-pass))
-      SMTP_PORT: ((smtp-port))
-      SMTP_CERT: ((smtp-cert))
-      MAIL_SENDER: ((smtp-from))
       TIME_STARTS_AT: ((time-starts-at-production))
       DRY_RUN: ((dry-run-production))
       DISABLE_PURGE: ((disable-purge-production))

--- a/cmd/purge/cf.go
+++ b/cmd/purge/cf.go
@@ -33,6 +33,10 @@ type SpacesClient interface {
 	Delete(ctx context.Context, guid string) (string, error)
 }
 
+type SpaceQuotasClient interface {
+	Single(ctx context.Context, opts *client.SpaceQuotaListOptions) (*resource.SpaceQuota, error)
+}
+
 type UsersClient interface {
 	ListAll(ctx context.Context, opts *client.UserListOptions) ([]*resource.User, error)
 }
@@ -43,6 +47,7 @@ type cfResourceClient struct {
 	Roles            RolesClient
 	ServiceInstances ServiceInstancesClient
 	Spaces           SpacesClient
+	SpaceQuotas      SpaceQuotasClient
 	Users            UsersClient
 }
 
@@ -69,6 +74,7 @@ func newCFClient(
 		Roles:            cf.Roles,
 		ServiceInstances: cf.ServiceInstances,
 		Spaces:           cf.Spaces,
+		SpaceQuotas:      cf.SpaceQuotas,
 		Users:            cf.Users,
 	}, nil
 }

--- a/cmd/purge/main.go
+++ b/cmd/purge/main.go
@@ -23,6 +23,7 @@ type Options struct {
 	DryRun            bool   `env:"DRY_RUN, default=true"`
 	TimeStartsAt      string `env:"TIME_STARTS_AT"`
 	DisablePurge      bool   `env:"DISABLE_PURGE, default=false"`
+	SandboxQuotaName  string `env:"SANDBOX_QUOTA_NAME, required"`
 	SMTPOptions
 }
 

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -50,7 +50,7 @@ func purgeAndRecreateSpace(
 	if len(developers) > 0 || len(managers) > 0 {
 		log.Printf("recreating space %s", details.Space.Name)
 		if err := recreateSpace(ctx, cfClient, opts, org, details); err != nil {
-			return fmt.Errorf("error recreating space developers/managers for space %s in org %s: %w", details.Space.Name, org.Name, err)
+			return fmt.Errorf("error recreating space %s in org %s: %w", details.Space.Name, org.Name, err)
 		}
 		log.Printf("recreating space roles")
 		if err := recreateSpaceDevsAndManagers(ctx, cfClient, details.Space.GUID, developers, managers); err != nil {

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -48,12 +48,9 @@ func purgeAndRecreateSpace(
 	}
 
 	if len(developers) > 0 || len(managers) > 0 {
-		spaceRequest := &resource.SpaceCreate{
-			Name:          details.Space.Name,
-			Relationships: details.Space.Relationships,
-		}
-		if _, err := cfClient.Spaces.Create(ctx, spaceRequest); err != nil {
-			return fmt.Errorf("error recreating space %s in org %s: %w", details.Space.Name, org.Name, err)
+		log.Printf("recreating space %s", details.Space.Name)
+		if err := recreateSpace(ctx, cfClient, opts, org, details); err != nil {
+			return fmt.Errorf("error recreating space developers/managers for space %s in org %s: %w", details.Space.Name, org.Name, err)
 		}
 		log.Printf("recreating space roles")
 		if err := recreateSpaceDevsAndManagers(ctx, cfClient, details.Space.GUID, developers, managers); err != nil {

--- a/cmd/purge/purge_test.go
+++ b/cmd/purge/purge_test.go
@@ -106,6 +106,12 @@ func (s *mockSpaces) Delete(ctx context.Context, guid string) (string, error) {
 	return "", nil
 }
 
+type mockSpaceQuotas struct{}
+
+func (q *mockSpaceQuotas) Single(ctx context.Context, opts *client.SpaceQuotaListOptions) (*resource.SpaceQuota, error) {
+	return nil, nil
+}
+
 type mockMailSender struct{}
 
 func (m *mockMailSender) sendMail(
@@ -175,6 +181,7 @@ func TestPurgeAndRecreateSpace(t *testing.T) {
 						},
 					},
 				},
+				SpaceQuotas: &mockSpaceQuotas{},
 			},
 			userGUIDs: map[string]bool{
 				"user-1": true,
@@ -277,6 +284,7 @@ func TestPurgeAndRecreateSpace(t *testing.T) {
 						},
 					},
 				},
+				SpaceQuotas: &mockSpaceQuotas{},
 			},
 			userGUIDs: map[string]bool{
 				"user-1": true,

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -106,7 +106,8 @@ func recreateSpace(
 				"error finding quota %s for space %s in org %s: %w",
 				options.SandboxQuotaName,
 				details.Space.Name,
-				organization.Name, err,
+				organization.Name,
+				err,
 			)
 		}
 		if spaceQuota != nil {

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -110,11 +110,15 @@ func recreateSpace(
 			)
 		}
 		if spaceQuota != nil {
-			spaceRequest.Relationships.Quota.Data.GUID = spaceQuota.GUID
+			spaceRequest.Relationships.Quota = &resource.ToOneRelationship{
+				Data: &resource.Relationship{
+					GUID: spaceQuota.GUID,
+				},
+			}
 		}
 	}
 	if _, err := cfClient.Spaces.Create(ctx, spaceRequest); err != nil {
-		return fmt.Errorf("error recreating space %s in org %s: %w", details.Space.Name, organization.Name, err)
+		return fmt.Errorf("error creating space %s in org %s: %w", details.Space.Name, organization.Name, err)
 	}
 	return nil
 }

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/mail"
 	"strings"
@@ -83,6 +84,39 @@ func listSpaceDevsAndManagers(
 		}
 	}
 	return
+}
+
+func recreateSpace(
+	ctx context.Context,
+	cfClient *cfResourceClient,
+	options Options,
+	organization *resource.Organization,
+	details SpaceDetails,
+) error {
+	spaceRequest := &resource.SpaceCreate{
+		Name:          details.Space.Name,
+		Relationships: details.Space.Relationships,
+	}
+	if spaceRequest.Relationships.Quota == nil {
+		spaceQuotaListOptions := client.NewSpaceQuotaListOptions()
+		spaceQuotaListOptions.Names.EqualTo(options.SandboxQuotaName)
+		spaceQuota, err := cfClient.SpaceQuotas.Single(ctx, spaceQuotaListOptions)
+		if err != nil {
+			return fmt.Errorf(
+				"error finding quota %s for space %s in org %s: %w",
+				options.SandboxQuotaName,
+				details.Space.Name,
+				organization.Name, err,
+			)
+		}
+		if spaceQuota != nil {
+			spaceRequest.Relationships.Quota.Data.GUID = spaceQuota.GUID
+		}
+	}
+	if _, err := cfClient.Spaces.Create(ctx, spaceRequest); err != nil {
+		return fmt.Errorf("error recreating space %s in org %s: %w", details.Space.Name, organization.Name, err)
+	}
+	return nil
 }
 
 func recreateSpaceDevsAndManagers(

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -99,7 +99,10 @@ func recreateSpace(
 	}
 	if spaceRequest.Relationships.Quota == nil {
 		spaceQuotaListOptions := client.NewSpaceQuotaListOptions()
-		spaceQuotaListOptions.Names.EqualTo(options.SandboxQuotaName)
+		spaceQuotaListOptions.OrganizationGUIDs.EqualTo(organization.GUID)
+		if options.SandboxQuotaName != "" {
+			spaceQuotaListOptions.Names.EqualTo(options.SandboxQuotaName)
+		}
 		spaceQuota, err := cfClient.SpaceQuotas.Single(ctx, spaceQuotaListOptions)
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
## Changes proposed in this pull request:

This is a fix for an observed issue in the pipeline that purges sandboxes where spaces were failing to recreate because the quota was not specified properly in the space creation parameters.

## security considerations

None, just fixing a bug in the behavior
