### PR TITLE
Fix purge space logic

### DIFF
--- a/cmd/purge/cf.go
+++ b/cmd/purge/cf.go
@@ -44,6 +44,10 @@ type UsersClient interface {
 	ListAll(ctx context.Context, opts *client.UserListOptions) ([]*resource.User, error)
 }
 
+type JobsClient interface {
+	PollComplete(ctx context.Context, jobGUID string, opts *client.PollingOptions) error
+}
+
 type cfResourceClient struct {
 	Applications     ApplicationsClient
 	Organizations    OrganizationsClient
@@ -52,6 +56,7 @@ type cfResourceClient struct {
 	Spaces           SpacesClient
 	SpaceQuotas      SpaceQuotasClient
 	Users            UsersClient
+	Jobs             JobsClient
 }
 
 func newCFClient(
@@ -79,5 +84,6 @@ func newCFClient(
 		Spaces:           cf.Spaces,
 		SpaceQuotas:      cf.SpaceQuotas,
 		Users:            cf.Users,
+		Jobs:             cf.Jobs,
 	}, nil
 }

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	ErrMaximumAttemptsReached = errors.New("maximum attempts reached")
+	ErrNoSpaceDeleteJobGUID = errors.New("cannot verify space deletion: no job GUID")
 )
 
 func purgeAndRecreateSpace(
@@ -77,7 +77,7 @@ func purgeAndRecreateSpace(
 
 func waitForSpaceDeletion(ctx context.Context, cfClient *cfResourceClient, deleteJobGUID string) error {
 	if deleteJobGUID == "" {
-		return fmt.Errorf("no job GUID for deletion of the space, cannot verify deletion")
+		return ErrNoSpaceDeleteJobGUID
 	}
 
 	pollingOptions := client.NewPollingOptions()

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -77,8 +77,7 @@ func purgeAndRecreateSpace(
 
 func waitForSpaceDeletion(ctx context.Context, cfClient *cfResourceClient, deleteJobGUID string) error {
 	if deleteJobGUID == "" {
-		log.Print("no job GUID for deletion of the space, cannot verify deletion")
-		return nil
+		return fmt.Errorf("no job GUID for deletion of the space, cannot verify deletion")
 	}
 
 	pollingOptions := client.NewPollingOptions()

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -49,19 +49,14 @@ func purgeAndRecreateSpace(
 	}
 
 	log.Printf("purging space %s", details.Space.Name)
-	if err := purgeSpace(ctx, cfClient, details.Space); err != nil {
+	deleteJobGUID, err := purgeSpace(ctx, cfClient, details.Space)
+	if err != nil {
 		return fmt.Errorf("error purging space %s in org %s: %w", details.Space.Name, org.Name, err)
 	}
 
-	err = waitUntilSpaceIsFullyDeleted(
-		ctx,
-		cfClient,
-		org,
-		details.Space.Name,
-		20,
-	)
+	err = waitForSpaceDeletion(ctx, cfClient, deleteJobGUID)
 	if err != nil {
-		return fmt.Errorf("error waiting until space %s in org %s is deleted: %w", details.Space.Name, org.Name, err)
+		return fmt.Errorf("error waiting for delete job %s to be complete: %w", deleteJobGUID, err)
 	}
 
 	log.Printf("recreating space %s", details.Space.Name)
@@ -80,47 +75,15 @@ func purgeAndRecreateSpace(
 	return nil
 }
 
-func waitUntilSpaceIsFullyDeleted(
-	ctx context.Context,
-	cfClient *cfResourceClient,
-	org *resource.Organization,
-	spaceName string,
-	maxAttempts int,
-) error {
-	spaceListOptions := client.NewSpaceListOptions()
-	spaceListOptions.OrganizationGUIDs.EqualTo(org.GUID)
-	spaceListOptions.Names.EqualTo(spaceName)
-	space, err := cfClient.Spaces.Single(ctx, spaceListOptions)
-	if err != nil {
-		return fmt.Errorf("error verifying deletion of space %s in org %s: %w", spaceName, org.Name, err)
+func waitForSpaceDeletion(ctx context.Context, cfClient *cfResourceClient, deleteJobGUID string) error {
+	if deleteJobGUID == "" {
+		log.Print("no job GUID for deletion of the space, cannot verify deletion")
+		return nil
 	}
 
-	attempts := 1
-	if maxAttempts == 0 {
-		maxAttempts = 20
-	}
-
-	for space != nil && attempts < maxAttempts {
-		log.Printf("space %s has not been fully deleted yet", spaceName)
-		space, err = cfClient.Spaces.Single(ctx, spaceListOptions)
-		if err != nil {
-			return fmt.Errorf("error verifying deletion of space %s in org %s: %w", spaceName, org.Name, err)
-		}
-		time.Sleep(100 * time.Millisecond)
-		attempts += 1
-	}
-
-	if attempts == maxAttempts && space != nil {
-		return fmt.Errorf(
-			"could not verify deletion of space %s in org %s after %d attempts: %w",
-			spaceName,
-			org.Name,
-			maxAttempts,
-			ErrMaximumAttemptsReached,
-		)
-	}
-
-	return nil
+	pollingOptions := client.NewPollingOptions()
+	pollingOptions.Timeout = 1 * time.Minute
+	return cfClient.Jobs.PollComplete(ctx, deleteJobGUID, pollingOptions)
 }
 
 func sendPurgeEmail(

--- a/cmd/purge/purge_test.go
+++ b/cmd/purge/purge_test.go
@@ -13,28 +13,19 @@ import (
 )
 
 type mockApplications struct {
-	listAppsErr error
-	apps        []*resource.App
-	spaceGUID   string
+	listAppsErr     error
+	apps            []*resource.App
+	deleteCallCount int
+	deleteErr       error
 }
 
 func (a *mockApplications) ListAll(ctx context.Context, opts *client.AppListOptions) ([]*resource.App, error) {
-	if a.listAppsErr != nil {
-		return nil, a.listAppsErr
-	}
-	expectedOpts := &client.AppListOptions{
-		SpaceGUIDs: client.Filter{
-			Values: []string{a.spaceGUID},
-		},
-	}
-	if !cmp.Equal(opts, expectedOpts) {
-		return nil, fmt.Errorf(cmp.Diff(opts, expectedOpts))
-	}
-	return a.apps, nil
+	return a.apps, a.listAppsErr
 }
 
 func (a *mockApplications) Delete(ctx context.Context, guid string) (string, error) {
-	return "", nil
+	a.deleteCallCount += 1
+	return "", a.deleteErr
 }
 
 type spaceCreatedRole struct {
@@ -82,6 +73,7 @@ type mockSpaces struct {
 	expectedSpaceCreateRequest *resource.SpaceCreate
 	space                      *resource.Space
 	deleteJobGUID              string
+	deleteErr                  error
 }
 
 func (s *mockSpaces) ListUsersAll(ctx context.Context, spaceGUID string, opts *client.UserListOptions) ([]*resource.User, error) {
@@ -106,7 +98,7 @@ func (s *mockSpaces) Create(ctx context.Context, r *resource.SpaceCreate) (*reso
 }
 
 func (s *mockSpaces) Delete(ctx context.Context, guid string) (string, error) {
-	return s.deleteJobGUID, nil
+	return s.deleteJobGUID, s.deleteErr
 }
 
 func (s *mockSpaces) Single(ctx context.Context, opts *client.SpaceListOptions) (*resource.Space, error) {

--- a/cmd/purge/purge_test.go
+++ b/cmd/purge/purge_test.go
@@ -177,7 +177,8 @@ func TestWaitForSpaceDeletion(t *testing.T) {
 		"error": {
 			cfClient: &cfResourceClient{
 				Jobs: &mockJobs{
-					pollErr: pollErr,
+					pollErr:         pollErr,
+					expectedJobGUID: "delete-1",
 				},
 			},
 			deleteJobGUID: "delete-1",

--- a/cmd/purge/sandbox.go
+++ b/cmd/purge/sandbox.go
@@ -156,8 +156,8 @@ func purgeSpace(
 	ctx context.Context,
 	cfClient *cfResourceClient,
 	space *resource.Space,
-) error {
-	_, spaceErr := cfClient.Spaces.Delete(ctx, space.GUID)
+) (string, error) {
+	jobGUID, spaceErr := cfClient.Spaces.Delete(ctx, space.GUID)
 	if spaceErr != nil {
 		apps, err := cfClient.Applications.ListAll(ctx, &client.AppListOptions{
 			SpaceGUIDs: client.Filter{
@@ -165,17 +165,17 @@ func purgeSpace(
 			},
 		})
 		if err != nil {
-			return err
+			return "", err
 		}
 		for _, app := range apps {
 			_, err := cfClient.Applications.Delete(ctx, app.GUID)
 			if err != nil {
-				return err
+				return "", err
 			}
 		}
-		return spaceErr
+		return "", spaceErr
 	}
-	return nil
+	return jobGUID, spaceErr
 }
 
 // listSandboxOrgs lists all sandbox organizations


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/cg-sandbox/issues/53

- Fix space purge logic to use the job GUID for the space deletion to ensure that the space is fully deleted before continuing with the recreation
- Update unit tests

## security considerations

None, just fixing broker behavior
